### PR TITLE
feat: improve html sementic

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -75,7 +75,9 @@
       {
         "namedComponents": "function-declaration"
       }
-    ]
+    ],
+    "react/prop-types": "off",
+    "react/require-default-props": "off"
   },
   "settings": {
     "import/resolver": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "@commitlint/cli": "17.0.2",
     "@commitlint/config-conventional": "17.0.2",
     "husky": "8.0.1",
-    "standard-version": "9.5.0"
+    "standard-version": "9.5.0",
+    "tslib": "2.4.0"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17 || ^18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ specifiers:
   husky: 8.0.1
   microbundle: 0.15.0
   standard-version: 9.5.0
+  tslib: 2.4.0
   typescript: 4.7.3
 
 devDependencies:
@@ -34,6 +35,7 @@ devDependencies:
   husky: 8.0.1
   microbundle: 0.15.0
   standard-version: 9.5.0
+  tslib: 2.4.0
   typescript: 4.7.3
 
 packages:

--- a/src/Form/Form.tsx
+++ b/src/Form/Form.tsx
@@ -2,18 +2,17 @@ import React, {
   FormHTMLAttributes,
   ReactNode,
   useCallback,
+  FormEventHandler,
 } from 'react';
 import {
-  FieldValues,
   mapValidationStatusesToOutcome,
   VALIDATION_OUTCOME,
 } from '../shared';
 import { FormContext, FormContextApi } from './contexts/FormContext';
 
-interface FormProps extends Omit<FormHTMLAttributes<HTMLFormElement>, 'onSubmit'> {
+interface FormProps extends FormHTMLAttributes<HTMLFormElement> {
   children: ReactNode,
   form: FormContextApi,
-  onSubmit?: (formValues: FieldValues) => void | Promise<void>,
 }
 
 /**
@@ -32,24 +31,29 @@ interface FormProps extends Omit<FormHTMLAttributes<HTMLFormElement>, 'onSubmit'
 export function Form({
   children,
   form,
-  onSubmit,
   ...otherProps
 }: FormProps) {
   const {
     getFormValues,
     formInternal: {
       getFormErrorsForNames,
+      getHandleFormSubmit,
     },
   } = form;
 
-  const handleSubmit: React.FormEventHandler<HTMLFormElement> = useCallback((event) => {
+  const handleSubmit: FormEventHandler<HTMLFormElement> = useCallback(async (event) => {
     event.preventDefault();
-    if (onSubmit) {
-      const validations = getFormErrorsForNames();
-      const isFormValid = mapValidationStatusesToOutcome(validations) === VALIDATION_OUTCOME.VALID;
-      if (isFormValid) onSubmit(getFormValues());
+
+    const validations = getFormErrorsForNames();
+    const isFormValid = mapValidationStatusesToOutcome(validations) === VALIDATION_OUTCOME.VALID;
+    if (isFormValid) {
+      const handleFormSubmit = getHandleFormSubmit();
+
+      if (handleFormSubmit) {
+        await handleFormSubmit(getFormValues());
+      }
     }
-  }, [getFormErrorsForNames, getFormValues, onSubmit]);
+  }, [getFormErrorsForNames, getFormValues, getHandleFormSubmit]);
 
   return (
     <FormContext.Provider value={form}>

--- a/src/Form/Form.tsx
+++ b/src/Form/Form.tsx
@@ -1,15 +1,23 @@
-import React, { ReactNode } from 'react';
+import React, {
+  FormHTMLAttributes,
+  ReactNode,
+  useCallback,
+} from 'react';
+import {
+  FieldValues,
+  mapValidationStatusesToOutcome,
+  VALIDATION_OUTCOME,
+} from '../shared';
 import { FormContext, FormContextApi } from './contexts/FormContext';
 
-interface FormProps {
+interface FormProps extends Omit<FormHTMLAttributes<HTMLFormElement>, 'onSubmit'> {
   children: ReactNode,
   form: FormContextApi,
+  onSubmit?: (formValues: FieldValues) => void | Promise<void>,
 }
 
 /**
  * Context to handle Form. Similar to <form> but using React Context
- * @param children - Children
- * @param form - Form from useForm hook
  * @example
  * ```
  * const form = useForm():
@@ -21,10 +29,33 @@ interface FormProps {
  * )
  * ```
  */
-export function Form({ children, form }: FormProps) {
+export function Form({
+  children,
+  form,
+  onSubmit,
+  ...otherProps
+}: FormProps) {
+  const {
+    getFormValues,
+    formInternal: {
+      getFormErrorsForNames,
+    },
+  } = form;
+
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = useCallback((event) => {
+    event.preventDefault();
+    if (onSubmit) {
+      const validations = getFormErrorsForNames();
+      const isFormValid = mapValidationStatusesToOutcome(validations) === VALIDATION_OUTCOME.VALID;
+      if (isFormValid) onSubmit(getFormValues());
+    }
+  }, [getFormErrorsForNames, getFormValues, onSubmit]);
+
   return (
     <FormContext.Provider value={form}>
-      {children}
+      <form {...otherProps} onSubmit={handleSubmit}>
+        {children}
+      </form>
     </FormContext.Provider>
   );
 }

--- a/src/Form/components/Field.tsx
+++ b/src/Form/components/Field.tsx
@@ -56,7 +56,10 @@ export interface FieldProps<T extends AnyRecord = AnyRecord> {
  * ```
  */
 export function Field({
-  name, children, render, data,
+  name,
+  children = null,
+  render,
+  data = undefined,
 }: FieldProps) {
   const {
     formInternal: {
@@ -145,8 +148,3 @@ export function composeEventHandlers(
     }
   );
 }
-
-Field.defaultProps = {
-  children: null,
-  data: undefined,
-};

--- a/src/Form/components/HiddenField.tsx
+++ b/src/Form/components/HiddenField.tsx
@@ -20,12 +20,13 @@ interface HiddenFieldProps {
  * )
  * ```
  */
-export function HiddenField(props: HiddenFieldProps) {
+export function HiddenField({
+  children = null,
+  ...props
+}: HiddenFieldProps) {
   return (
-    <Field {...props} render={() => null} />
+    <Field {...props} render={() => null}>
+      {children}
+    </Field>
   );
 }
-
-HiddenField.defaultProps = {
-  children: null,
-};

--- a/src/Form/components/Rule.tsx
+++ b/src/Form/components/Rule.tsx
@@ -4,7 +4,7 @@ import { Validator } from '../types/Validation';
 
 interface RuleProps {
   /**
-   * Message displayed when error is true
+   * Function run for the validation
    */
   validationFn: Validator,
   /**

--- a/src/Form/components/Rule.tsx
+++ b/src/Form/components/Rule.tsx
@@ -1,20 +1,23 @@
-import { ReactNode, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useRuleContext } from '../contexts/RuleContext';
 import { Validator } from '../types/Validation';
 
 interface RuleProps {
+  /**
+   * Message displayed when error is true
+   */
   validationFn: Validator,
+  /**
+   * Message displayed when error is true
+   */
   message: string,
-  children?: ReactNode,
+  /**
+   * Is validation function run with debounce
+   */
   isDebounced?: boolean,
 }
 
 /**
- *
- * @param message - Message when error is true
- * @param children -  Children
- * @param validationFn - Function run for the validation
- * @param isDebounced - Is validation function run with debounce
  * @example
  * ```
  * <TextField name="foo">
@@ -26,7 +29,9 @@ interface RuleProps {
  * ```
  */
 export function Rule({
-  message, children, validationFn, isDebounced = false,
+  message,
+  validationFn,
+  isDebounced = false,
 }: RuleProps) {
   const { registerRule, unregisterRule } = useRuleContext();
 
@@ -35,10 +40,5 @@ export function Rule({
     return () => unregisterRule(validationFn, isDebounced);
   }, [isDebounced, message, registerRule, unregisterRule, validationFn]);
 
-  return children;
+  return null;
 }
-
-Rule.defaultProps = {
-  children: null,
-  isDebounced: false,
-};

--- a/src/Form/contexts/FormContext.ts
+++ b/src/Form/contexts/FormContext.ts
@@ -58,6 +58,7 @@ export interface FormInternal {
     name: string,
     validationStatus: ValidationStatus,
   ) => void
+  getHandleFormSubmit: () => ((formValues: FieldValues) => (void | Promise<void>)) | undefined,
 }
 
 export interface FormContextApi {
@@ -68,6 +69,7 @@ export interface FormContextApi {
   getFormValues: () => FieldValues,
   resetForm: () => void,
   setFormValues: (newValues: FieldValues, eraseAll?: boolean) => void,
+  handleSubmit: (submitCallback: (formValues: FieldValues) => (void | Promise<void>)) => () => void,
 }
 
 export const FORM_INTERVAL_DEFAULT: FormInternal = {
@@ -82,6 +84,7 @@ export const FORM_INTERVAL_DEFAULT: FormInternal = {
   getFormValuesForNames: (): FieldValues => ({}),
   getFormErrorsForNames: (): Record<string, ValidationStatus> => ({}),
   updateValidationStatus: (): void => {},
+  getHandleFormSubmit: () => undefined,
 };
 
 export const CONTEXT_FORM_DEFAULT: FormContextApi = {
@@ -89,6 +92,7 @@ export const CONTEXT_FORM_DEFAULT: FormContextApi = {
   getFormValues: () => ({}),
   resetForm: () => {},
   setFormValues: () => {},
+  handleSubmit: () => () => {},
 };
 
 export const FormContext = createContext(

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export {
 } from './Wizard';
 export {
   FieldValue,
+  FieldValues,
   VALIDATION_OUTCOME,
   mapValidationStatusesToOutcome,
 } from './shared';


### PR DESCRIPTION
Closes #5 

Adding possibility to trigger onSubmit with the following syntax.
 
```tsx

const form = useForm();

const onSubmit = () => console.log("hello world");

return (
  <Form form={form}>
    <input name="input" />

    <button
      type="submit"
      onClick={form.handleSubmit(onSubmit}}
     />
  </Form>
)
```