### PR TITLE
feat: move internal logic of `useWizard` inside `wizardInternal`

### DIFF
--- a/src/wizard/components/Placeholder.tsx
+++ b/src/wizard/components/Placeholder.tsx
@@ -7,7 +7,9 @@ export interface PlaceholderProps {
 }
 
 export function Placeholder({ placement, children }: PlaceholderProps) {
-  const { updatePlaceholderContent, resetPlaceholderContent } = useWizardContext();
+  const {
+    wizardInternal: { updatePlaceholderContent, resetPlaceholderContent },
+  } = useWizardContext();
 
   useEffect(() => {
     updatePlaceholderContent(placement, children);

--- a/src/wizard/components/Step.tsx
+++ b/src/wizard/components/Step.tsx
@@ -39,7 +39,10 @@ export function Step<Steps extends string, WizardValues extends Record<Steps, Fi
 }: StepProps<Steps, WizardValues, Step>) {
   const wizard = useWizardContext<Steps, WizardValues>();
 
-  const { registerStep, unregisterStep, currentStep, setIsStepReady } = wizard;
+  const {
+    currentStep,
+    wizardInternal: { registerStep, unregisterStep, setIsStepReady },
+  } = wizard;
 
   // When Step is used outside of wizard context, it will throw an error
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/wizard/contexts/WizardContext.ts
+++ b/src/wizard/contexts/WizardContext.ts
@@ -5,59 +5,83 @@ import { PlaceholderContentSetter, StepValidator } from '../types';
 export type ValidationStatusesSetter = Dispatch<SetStateAction<VALIDATION_OUTCOME>>;
 
 export interface WizardContextApi<Steps extends string, WizardValues extends Record<Steps, FieldValues>> {
+  wizardInternal: {
+    updatePlaceholderContent(placement: string, children: ReactNode): void;
+
+    resetPlaceholderContent(placement?: string): void;
+
+    registerPlaceholder(
+      placeholderContentSetter: PlaceholderContentSetter,
+      stepStatusSetter: ValidationStatusesSetter,
+    ): void;
+
+    unregisterPlaceholder(
+      placeholderContentSetter: PlaceholderContentSetter,
+      stepStatusSetter: ValidationStatusesSetter,
+    ): void;
+
+    registerStep<Step extends Steps>(
+      name: Step,
+      validationFn?: StepValidator<Steps, WizardValues, Step>,
+      noFooter?: boolean,
+      title?: string,
+    ): void;
+
+    unregisterStep(name: Steps): void;
+
+    setIsStepReady: Dispatch<SetStateAction<boolean>>;
+
+    stepStatusSetter: ValidationStatusesSetter;
+
+    setValuesGetterForCurrentStep(stepValuesGetter: () => FieldValues | undefined): void;
+  };
+
   steps: Steps[];
+
   currentStep: Steps | undefined;
-  registerStep<Step extends Steps>(
-    name: Step,
-    validationFn?: StepValidator<Steps, WizardValues, Step>,
-    noFooter?: boolean,
-    title?: string,
-  ): void;
-  unregisterStep(name: Steps): void;
+
   handleOnNext(): Promise<void>;
+
   handleOnPrevious(): void;
-  updatePlaceholderContent(placement: string, children: ReactNode): void;
-  resetPlaceholderContent(placement?: string): void;
-  registerPlaceholder(
-    placeholderContentSetter: PlaceholderContentSetter,
-    stepStatusSetter: ValidationStatusesSetter,
-  ): void;
-  unregisterPlaceholder(
-    placeholderContentSetter: PlaceholderContentSetter,
-    stepStatusSetter: ValidationStatusesSetter,
-  ): void;
+
   isLastStep: boolean;
+
   isFirstStep: boolean;
+
   hasNoFooter: boolean;
-  stepStatusSetter: ValidationStatusesSetter;
+
   isStepReady: boolean;
+
   stepsTitles: { name: Steps; title: string | undefined }[];
-  setIsStepReady: Dispatch<SetStateAction<boolean>>;
-  setValuesGetterForCurrentStep(stepValuesGetter: () => FieldValues | undefined): void;
+
   getValuesOfCurrentStep<Step extends Steps>(): WizardValues[Step] | undefined;
+
   getValuesOfStep<Step extends Steps>(stepName: Step): WizardValues[Step] | undefined;
+
   getValuesOfSteps(): WizardValues;
 }
 
 export const CONTEXT_WIZARD_DEFAULT: WizardContextApi<string, Record<string, never>> = {
+  wizardInternal: {
+    updatePlaceholderContent: () => {},
+    resetPlaceholderContent: () => {},
+    registerStep: () => {},
+    unregisterStep: () => {},
+    registerPlaceholder: () => {},
+    unregisterPlaceholder: () => {},
+    stepStatusSetter: () => {},
+    setIsStepReady: () => {},
+    setValuesGetterForCurrentStep: () => {},
+  },
   steps: [],
   currentStep: undefined,
-  registerStep: () => {},
-  unregisterStep: () => {},
   handleOnNext: async () => {},
   handleOnPrevious: () => {},
-  updatePlaceholderContent: () => {},
-  resetPlaceholderContent: () => {},
-  registerPlaceholder: () => {},
-  unregisterPlaceholder: () => {},
   isLastStep: false,
   isFirstStep: false,
   hasNoFooter: true,
-  stepStatusSetter: () => {},
   isStepReady: false,
   stepsTitles: [],
-  setIsStepReady: () => {},
-  setValuesGetterForCurrentStep: () => {},
   getValuesOfCurrentStep: () => undefined,
   getValuesOfStep: () => undefined,
   getValuesOfSteps: () => ({}),

--- a/src/wizard/hooks/usePlaceholder.ts
+++ b/src/wizard/hooks/usePlaceholder.ts
@@ -11,9 +11,13 @@ interface UsePlaceholder {
   stepStatus: VALIDATION_OUTCOME;
 }
 export function usePlaceholder(): UsePlaceholder {
-  const { handleOnNext, handleOnPrevious, registerPlaceholder, unregisterPlaceholder } = useWizardContext();
+  const {
+    handleOnNext,
+    handleOnPrevious,
+    wizardInternal: { registerPlaceholder, unregisterPlaceholder },
+  } = useWizardContext();
 
-  const [placeholderContent, setPlaceholderContent] = useState<PlaceholderContent>({} as PlaceholderContent);
+  const [placeholderContent, setPlaceholderContent] = useState<PlaceholderContent>({});
   const [isLoading, setIsLoading] = useState(false);
   const [stepStatus, setStepStatus] = useState<VALIDATION_OUTCOME>(VALIDATION_OUTCOME.VALID);
 

--- a/src/wizard/hooks/useStepForm.ts
+++ b/src/wizard/hooks/useStepForm.ts
@@ -29,7 +29,10 @@ interface UseStepFormApi<T extends FieldValues> {
  */
 export function useStepForm<T extends FieldValues>(props: UseFormOptions<T>): UseStepFormApi<T> {
   const form = useForm(props);
-  const { stepStatusSetter, setValuesGetterForCurrentStep, getValuesOfCurrentStep } = useWizardContext();
+  const {
+    wizardInternal: { stepStatusSetter, setValuesGetterForCurrentStep },
+    getValuesOfCurrentStep,
+  } = useWizardContext();
   const valuesHasBeenInitializedRef = useRef(false);
 
   const {

--- a/src/wizard/hooks/useWizard.ts
+++ b/src/wizard/hooks/useWizard.ts
@@ -155,7 +155,7 @@ export function useWizard<Steps extends string, WizardValues extends Record<Step
     saveValuesOfCurrentStepInWizardValues();
 
     const index = steps.indexOf(currentStep);
-    // If has next step, go to next step
+    // If it has next step, go to next step
     if (hasNextStep(index, steps)) {
       setIsStepReady(false);
       // Ensure that current step change is done after isStepReady
@@ -264,20 +264,22 @@ export function useWizard<Steps extends string, WizardValues extends Record<Step
     () =>
       Object.defineProperties(
         {
+          wizardInternal: {
+            updatePlaceholderContent,
+            resetPlaceholderContent,
+            registerStep,
+            unregisterStep,
+            registerPlaceholder,
+            unregisterPlaceholder,
+            stepStatusSetter,
+            setIsStepReady,
+            setValuesGetterForCurrentStep,
+          },
           steps,
           currentStep,
-          registerStep,
-          unregisterStep,
           handleOnNext,
           handleOnPrevious,
-          updatePlaceholderContent,
-          resetPlaceholderContent,
-          registerPlaceholder,
-          unregisterPlaceholder,
-          stepStatusSetter,
           isStepReady,
-          setIsStepReady,
-          setValuesGetterForCurrentStep,
           getValuesOfCurrentStep,
           getValuesOfStep,
           getValuesOfSteps,


### PR DESCRIPTION
Moving internal function of wizard under `wizardInternal` (similar to `formWizard` in `useForm`) in order to simplify the public API available through `useWizard` or `useWizardContext`:

Before:
```tsx
steps: [],
  currentStep: undefined,
  registerStep: () => {},
  unregisterStep: () => {},
  handleOnNext: async () => {},
  handleOnPrevious: () => {},
  updatePlaceholderContent: () => {},
  resetPlaceholderContent: () => {},
  registerPlaceholder: () => {},
  unregisterPlaceholder: () => {},
  isLastStep: false,
  isFirstStep: false,
  hasNoFooter: true,
  stepStatusSetter: () => {},
  isStepReady: false,
  stepsTitles: [],
  setIsStepReady: () => {},
  setValuesGetterForCurrentStep: () => {},
  getValuesOfCurrentStep: () => undefined,
  getValuesOfStep: () => undefined,
  getValuesOfSteps: () => ({}),
```

After:
```tsx
wizardInternal: {
    updatePlaceholderContent: () => {},
    resetPlaceholderContent: () => {},
    registerStep: () => {},
    unregisterStep: () => {},
    registerPlaceholder: () => {},
    unregisterPlaceholder: () => {},
    stepStatusSetter: () => {},
    setIsStepReady: () => {},
    setValuesGetterForCurrentStep: () => {},
  },
  steps: [],
  currentStep: undefined,
  handleOnNext: async () => {},
  handleOnPrevious: () => {},
  isLastStep: false,
  isFirstStep: false,
  hasNoFooter: true,
  isStepReady: false,
  stepsTitles: [],
  getValuesOfCurrentStep: () => undefined,
  getValuesOfStep: () => undefined,
  getValuesOfSteps: () => ({}),
```