### PR TITLE
feat: create `addGlobalValidationStatusSubscriber` and `removeGlobalValidationStatusSubscriber functions to handle global errors subscribers.

### DIFF
--- a/src/form/contexts/FormContext.ts
+++ b/src/form/contexts/FormContext.ts
@@ -45,7 +45,9 @@ export interface FormInternal<T extends FieldValues> {
    * Add new subscriber watching all registered field errors.
    * @param publish Callback to publish new value
    */
-  addValidationStatusSubscriber(publish: Dispatch<SetStateAction<FormValidations<T, keyof T>>>): void;
+  addGlobalValidationStatusSubscriber(
+    publish: Dispatch<SetStateAction<PartialRecord<keyof T, ValidationStatus | undefined>>>,
+  ): void;
 
   /**
    * Add new subscriber watching a list of field errors.
@@ -95,7 +97,9 @@ export interface FormInternal<T extends FieldValues> {
    * Remove subscriber watching all registered field errors.
    * @param publish Callback used to publish new value
    */
-  removeValidationStatusSubscriber(publish: Dispatch<SetStateAction<FormValidations<T, keyof T>>>): void;
+  removeGlobalValidationStatusSubscriber(
+    publish: Dispatch<SetStateAction<PartialRecord<keyof T, ValidationStatus | undefined>>>,
+  ): void;
 
   /**
    * Remove validation status subscriber for given fields.
@@ -185,11 +189,13 @@ export const FORM_INTERVAL_DEFAULT: FormInternal<any> = {
   getFormErrorsForNames: (): Record<string, ValidationStatus> => ({}),
   addGlobalValueSubscriber: (): void => {},
   addValueSubscriber: (): void => {},
+  addGlobalValidationStatusSubscriber: (): void => {},
   addValidationStatusSubscriber: (): void => {},
   registerField: (): void => {},
   unregisterField: (): void => {},
   removeGlobalValueSubscriber: (): void => {},
   removeValueSubscriber: (): void => {},
+  removeGlobalValidationStatusSubscriber: (): void => {},
   removeValidationStatusSubscriber: (): void => {},
   handleOnChange: (): void => {},
   handleOnBlur: (): Promise<void> => Promise.resolve(),

--- a/src/form/hooks/useValidations.ts
+++ b/src/form/hooks/useValidations.ts
@@ -1,40 +1,17 @@
 import { useEffect, useState } from 'react';
-import { FieldValues } from '../../shared';
+import { FieldValues, PartialRecord, ValidationStatus } from '../../shared';
 import { CONTEXT_FORM_DEFAULT, FormContextApi, useFormContext } from '../contexts/FormContext';
 import { FormValidations } from '../types/FormValidations';
 
-export function useValidations<T extends FieldValues>(
-  names: undefined,
+function useGlobalValidationInternal<T extends FieldValues>(
   form?: FormContextApi<T>,
-): FormValidations<T, keyof T>;
-export function useValidations<T extends FieldValues, K extends keyof T>(
-  names: K[],
-  form?: FormContextApi<T>,
-): FormValidations<T, K>;
-
-/**
- * Build hook to watch values.
- * If names is not defined, watch all values
- * @param names (optional) Field names
- * @param form (optional) form to use. If it's not given, form context is used.
- * @return
- * ```
- *   const { foo } = useValidations(['foo']);
- *   useEffect(() => {
- *     console.log(foo);
- *   },[])
- * ```
- */
-export function useValidations<T extends FieldValues, K extends keyof T>(
-  names?: K[],
-  form?: FormContextApi<T>,
-): FormValidations<T, keyof T> | FormValidations<T, K> {
+): PartialRecord<keyof T, ValidationStatus | undefined> {
   const formContext = useFormContext<T>();
   const {
-    formInternal: { addValidationStatusSubscriber, removeValidationStatusSubscriber },
+    formInternal: { addGlobalValidationStatusSubscriber, removeGlobalValidationStatusSubscriber },
   } = form || formContext;
-  const [currentValidations, setCurrentValidations] = useState<FormValidations<T, keyof T> | FormValidations<T, K>>(
-    {} as FormValidations<T, keyof T> | FormValidations<T, K>,
+  const [currentValidations, setCurrentValidations] = useState<PartialRecord<keyof T, ValidationStatus | undefined>>(
+    {},
   );
 
   if (!form && formContext === CONTEXT_FORM_DEFAULT) {
@@ -42,10 +19,75 @@ export function useValidations<T extends FieldValues, K extends keyof T>(
   }
 
   useEffect(() => {
-    addValidationStatusSubscriber<K>(setCurrentValidations, names as K[]);
-    return () => removeValidationStatusSubscriber<K>(setCurrentValidations, names as K[]);
+    addGlobalValidationStatusSubscriber(setCurrentValidations);
+    return () => removeGlobalValidationStatusSubscriber(setCurrentValidations);
+  }, [addGlobalValidationStatusSubscriber, removeGlobalValidationStatusSubscriber]);
+
+  return currentValidations;
+}
+
+function useValidationsInternal<T extends FieldValues, K extends keyof T>(
+  form: FormContextApi<T> | undefined,
+  names: K[],
+): FormValidations<T, K> {
+  const formContext = useFormContext<T>();
+  const {
+    formInternal: { addValidationStatusSubscriber, removeValidationStatusSubscriber },
+  } = form || formContext;
+  const [currentValidations, setCurrentValidations] = useState<FormValidations<T, K>>({} as FormValidations<T, K>);
+
+  if (!form && formContext === CONTEXT_FORM_DEFAULT) {
+    throw new Error('No form context could be found.');
+  }
+
+  useEffect(() => {
+    addValidationStatusSubscriber<K>(setCurrentValidations, names);
+    return () => removeValidationStatusSubscriber<K>(setCurrentValidations, names);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [addValidationStatusSubscriber, names?.join(), removeValidationStatusSubscriber]);
 
   return currentValidations;
+}
+
+/**
+ * Watch all registered fields errors
+ * @param names undefined
+ * @param form You can give a FormContext if the hook is not in `Form`
+ * @example
+ * ```
+ *  const { foo, bar } = useValidations();
+ *   useEffect(() => {
+ *     console.log(foo, bar);
+ *   },[foo, bar])
+ * ```
+ */
+export function useValidations<T extends FieldValues>(
+  names: undefined,
+  form?: FormContextApi<T>,
+): PartialRecord<keyof T, ValidationStatus | undefined>;
+
+/**
+ * Watch a list of registered fields errors
+ * @param names List of watched field names
+ * @param form You can give a FormContext if the hook is not in `Form`
+ * @example
+ * ```
+ * const { foo } = useValidations(['foo']);
+ *   useEffect(() => {
+ *     console.log(foo);
+ *   },[foo])
+ * ```
+ */
+export function useValidations<T extends FieldValues, K extends keyof T>(
+  names: K[],
+  form?: FormContextApi<T>,
+): FormValidations<T, K>;
+
+export function useValidations<T extends FieldValues, K extends keyof T>(names?: K[], form?: FormContextApi<T>) {
+  if (names) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    return useValidationsInternal(form, names);
+  }
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  return useGlobalValidationInternal(form);
 }


### PR DESCRIPTION
`addValidationStatusSubscriber` and `removeValidationStatusSubscriber` can no longer
 be used to handle global errors watchers